### PR TITLE
Use total value to compute relative month value

### DIFF
--- a/code/06-finished/src/components/Chart/Chart.js
+++ b/code/06-finished/src/components/Chart/Chart.js
@@ -15,6 +15,7 @@ const Chart = (props) => {
           value={dataPoint.value}
           maxValue={totalMaximum}
           label={dataPoint.label}
+          totalValue={props.totalValue}
         />
       ))}
     </div>

--- a/code/06-finished/src/components/Chart/ChartBar.js
+++ b/code/06-finished/src/components/Chart/ChartBar.js
@@ -6,7 +6,7 @@ const ChartBar = (props) => {
   let barFillHeight = '0%';
 
   if (props.maxValue > 0) {
-    barFillHeight = Math.round((props.value / props.maxValue) * 100) + '%';
+    barFillHeight = Math.round((props.value / props.totalValue) * 100) + '%';
   }
 
   return (

--- a/code/06-finished/src/components/Expenses/ExpensesChart.js
+++ b/code/06-finished/src/components/Expenses/ExpensesChart.js
@@ -18,12 +18,14 @@ const ExpensesChart = (props) => {
     { label: 'Dec', value: 0 },
   ];
 
+  let totalAmount = 0;
   for (const expense of props.expenses) {
     const expenseMonth = expense.date.getMonth(); // starting at 0 => January => 0
     chartDataPoints[expenseMonth].value += expense.amount;
+    totalAmount += expense.amount;
   }
 
-  return <Chart dataPoints={chartDataPoints} />;
+  return <Chart dataPoints={chartDataPoints} totalValue={totalAmount} />;
 };
 
 export default ExpensesChart;


### PR DESCRIPTION
As already stated in issue #18 the chartbar does not seem to be well calculated.

The bar should represent the relative amount of expenses of each month in relation with the total expenses of the year. With the current implementation it compares for each month with the maximum value, which is wrong.

This PR fixes the problem.