### PR TITLE
Removed the / from node_modules for subfolders containing node modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,7 @@
 # See https://help.github.com/articles/ignoring-files/ for more about ignoring files.
 
 # dependencies
-/node_modules
+node_modules
 /.pnp
 .pnp.js
 


### PR DESCRIPTION
Removed the / from node_modules so that subfolders containing a node_modules folder also get ignored.

Hi Max! When cloning your repository and working inside one of your ./code/... subfolders inside any of the module's branches, the node_modules don't get ignored. This is a little bit painful even for vscode watching changes from 5000+ files. So it would be nice, if you could merge this little change into your module's branches.

Best
Alex