### PR TITLE
Contribution to Button CSS

### DIFF
--- a/extra-files/Button.module.css
+++ b/extra-files/Button.module.css
@@ -5,6 +5,7 @@
   color: white;
   padding: 0.25rem 1rem;
   cursor: pointer;
+  display: inline-block;
 }
 
 .button:hover,


### PR DESCRIPTION
Right now, if I use this css file, the button covers the full-width of the card which looks ugly.
So I added `"display: inline-block"` to make the button takes up space of its content-width.