### PR TITLE
Change ReactDOM.render to createRoot

### DIFF
--- a/code/01-starting-project/src/index.js
+++ b/code/01-starting-project/src/index.js
@@ -1,7 +1,8 @@
-import React from 'react';
-import ReactDOM from 'react-dom/client';
+import React from "react";
+import ReactDOM from "react-dom/client";
 
-import './index.css';
-import App from './App';
+import "./index.css";
+import App from "./App";
 
-ReactDOM.render(<App />, document.getElementById('root'));
+const root = ReactDOM.createRoot(document.getElementById("root"));
+root.render(<App />);


### PR DESCRIPTION
ReactDOM.render is no longer supported in React 18. Use createRoot instead.
https://reactjs.org/link/switch-to-createroot