### PR TITLE
FIX: app crash when opening Modal

### DIFF
--- a/code/01-starting-project/src/components/UI/Modal.js
+++ b/code/01-starting-project/src/components/UI/Modal.js
@@ -1,5 +1,5 @@
 import { Fragment } from 'react';
-import ReactDOM from 'react-dom/client';
+import ReactDOM from 'react-dom';
 
 import classes from './Modal.module.css';
 

--- a/code/02-fetching-meals-via-http/src/components/UI/Modal.js
+++ b/code/02-fetching-meals-via-http/src/components/UI/Modal.js
@@ -1,5 +1,5 @@
 import { Fragment } from 'react';
-import ReactDOM from 'react-dom/client';
+import ReactDOM from 'react-dom';
 
 import classes from './Modal.module.css';
 

--- a/code/03-handling-errors/src/components/UI/Modal.js
+++ b/code/03-handling-errors/src/components/UI/Modal.js
@@ -1,5 +1,5 @@
 import { Fragment } from 'react';
-import ReactDOM from 'react-dom/client';
+import ReactDOM from 'react-dom';
 
 import classes from './Modal.module.css';
 

--- a/code/04-adding-a-checkout-form/src/components/UI/Modal.js
+++ b/code/04-adding-a-checkout-form/src/components/UI/Modal.js
@@ -1,5 +1,5 @@
 import { Fragment } from 'react';
-import ReactDOM from 'react-dom/client';
+import ReactDOM from 'react-dom';
 
 import classes from './Modal.module.css';
 

--- a/code/05-adding-form-validation/src/components/UI/Modal.js
+++ b/code/05-adding-form-validation/src/components/UI/Modal.js
@@ -1,5 +1,5 @@
 import { Fragment } from 'react';
-import ReactDOM from 'react-dom/client';
+import ReactDOM from 'react-dom';
 
 import classes from './Modal.module.css';
 

--- a/code/06-submitting-sending-cart-data/src/components/UI/Modal.js
+++ b/code/06-submitting-sending-cart-data/src/components/UI/Modal.js
@@ -1,5 +1,5 @@
 import { Fragment } from 'react';
-import ReactDOM from 'react-dom/client';
+import ReactDOM from 'react-dom';
 
 import classes from './Modal.module.css';
 

--- a/code/07-finished/src/components/UI/Modal.js
+++ b/code/07-finished/src/components/UI/Modal.js
@@ -1,5 +1,5 @@
 import { Fragment } from 'react';
-import ReactDOM from 'react-dom/client';
+import ReactDOM from 'react-dom';
 
 import classes from './Modal.module.css';
 


### PR DESCRIPTION
App was crashing when attempting to open the Modal. Fixed by changing ReactDOM imports. 
Thank you for such a complete and well explained React course.