### PR TITLE
06 upgraded react-scripts to v5

### DIFF
--- a/code/01-starting-project/package.json
+++ b/code/01-starting-project/package.json
@@ -8,7 +8,7 @@
     "@testing-library/user-event": "^12.5.0",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
-    "react-scripts": "4.0.1",
+    "react-scripts": "5.0.1",
     "web-vitals": "^0.2.4"
   },
   "scripts": {

--- a/code/02-setting-dynamic-inline-styles/package.json
+++ b/code/02-setting-dynamic-inline-styles/package.json
@@ -8,7 +8,7 @@
     "@testing-library/user-event": "^12.5.0",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
-    "react-scripts": "4.0.1",
+    "react-scripts": "5.0.1",
     "web-vitals": "^0.2.4"
   },
   "scripts": {

--- a/code/03-setting-css-classes-dynamically/package.json
+++ b/code/03-setting-css-classes-dynamically/package.json
@@ -8,7 +8,7 @@
     "@testing-library/user-event": "^12.5.0",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
-    "react-scripts": "4.0.1",
+    "react-scripts": "5.0.1",
     "web-vitals": "^0.2.4"
   },
   "scripts": {

--- a/code/04-introducing-styled-components/package.json
+++ b/code/04-introducing-styled-components/package.json
@@ -8,7 +8,7 @@
     "@testing-library/user-event": "^12.5.0",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
-    "react-scripts": "4.0.1",
+    "react-scripts": "5.0.1",
     "web-vitals": "^0.2.4",
     "styled-components": "^5.0.1"
   },

--- a/code/05-styled-components-dynamic-props/package.json
+++ b/code/05-styled-components-dynamic-props/package.json
@@ -8,7 +8,7 @@
     "@testing-library/user-event": "^12.5.0",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
-    "react-scripts": "4.0.1",
+    "react-scripts": "5.0.1",
     "web-vitals": "^0.2.4",
     "styled-components": "^5.0.1"
   },

--- a/code/06-styled-components-media-queries/package.json
+++ b/code/06-styled-components-media-queries/package.json
@@ -8,7 +8,7 @@
     "@testing-library/user-event": "^12.5.0",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
-    "react-scripts": "4.0.1",
+    "react-scripts": "5.0.1",
     "web-vitals": "^0.2.4",
     "styled-components": "^5.0.1"
   },

--- a/code/07-using-css-modules/package.json
+++ b/code/07-using-css-modules/package.json
@@ -8,7 +8,7 @@
     "@testing-library/user-event": "^12.5.0",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
-    "react-scripts": "4.0.1",
+    "react-scripts": "5.0.1",
     "web-vitals": "^0.2.4",
     "styled-components": "^5.0.1"
   },

--- a/code/08-finished/package.json
+++ b/code/08-finished/package.json
@@ -8,7 +8,7 @@
     "@testing-library/user-event": "^12.5.0",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
-    "react-scripts": "4.0.1",
+    "react-scripts": "5.0.1",
     "web-vitals": "^0.2.4",
     "styled-components": "^5.0.1"
   },


### PR DESCRIPTION
I'm using WSL2 to follow the course, and there was an issue with this example project: auto-reload didn't work. It was throwing this error every time I updated a file and stopped responding:
```
VM256:2 Uncaught ReferenceError: process is not defined
    at 4043 (<anonymous>:2:13168)
    at r (<anonymous>:2:306599)
    at 8048 (<anonymous>:2:9496)
    at r (<anonymous>:2:306599)
    at 8641 (<anonymous>:2:1379)
    at r (<anonymous>:2:306599)
    at <anonymous>:2:315627
    at <anonymous>:2:324225
    at <anonymous>:2:324229
    at e.onload (index.js:1:1)
```

I solved it by upgrading `react-scripts` to v5.0.1 😄 