### PR TITLE
fixed bug in react 18 with children prop

### DIFF
--- a/code/16-finished/.gitignore
+++ b/code/16-finished/.gitignore
@@ -1,0 +1,25 @@
+.DS_Store
+.vscode
+# See https://help.github.com/articles/ignoring-files/ for more about ignoring files.
+
+# dependencies
+/node_modules
+/.pnp
+.pnp.js
+
+# testing
+/coverage
+
+# production
+/build
+
+# misc
+.DS_Store
+.env.local
+.env.development.local
+.env.test.local
+.env.production.local
+
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*

--- a/code/16-finished/src/store/todos-context.tsx
+++ b/code/16-finished/src/store/todos-context.tsx
@@ -14,7 +14,9 @@ export const TodosContext = React.createContext<TodosContextObj>({
   removeTodo: (id: string) => {},
 });
 
-const TodosContextProvider: React.FC = (props) => {
+// In React 18.x you have to include the children prop yourself, I wrote solution below
+
+const TodosContextProvider: React.FC<{ children: JSX.Element | JSX.Element[] }> = (props) => {
   const [todos, setTodos] = useState<Todo[]>([]);
 
   const addTodoHandler = (todoText: string) => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "react-complete-guide-code",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {}
+}


### PR DESCRIPTION
With React 18 using {props.children} returns error »Property 'children' does not exist on type {}«.
Add typing children prop as a JSX element or array of elements fixed a bug.