### PR TITLE
React 18 requires setting up children prop

### DIFF
--- a/code/16-finished/src/store/todos-context.tsx
+++ b/code/16-finished/src/store/todos-context.tsx
@@ -14,7 +14,7 @@ export const TodosContext = React.createContext<TodosContextObj>({
   removeTodo: (id: string) => {},
 });
 
-const TodosContextProvider: React.FC = (props) => {
+const TodosContextProvider = ({ children }: { children: React.ReactNode }) => {
   const [todos, setTodos] = useState<Todo[]>([]);
 
   const addTodoHandler = (todoText: string) => {
@@ -39,7 +39,7 @@ const TodosContextProvider: React.FC = (props) => {
 
   return (
     <TodosContext.Provider value={contextValue}>
-      {props.children}
+      {children}
     </TodosContext.Provider>
   );
 };


### PR DESCRIPTION
Just my two cents, since React 18 requires setting up children prop, I have created a workaround to getting the children prop back without the React,FC.