### PR TITLE
Update next to avoid issue during build

### DIFF
--- a/code/06-onwards-to-a-bigger-project-starting-project/package.json
+++ b/code/06-onwards-to-a-bigger-project-starting-project/package.json
@@ -8,7 +8,7 @@
     "start": "next start"
   },
   "dependencies": {
-    "next": "10.0.6",
+    "next": "10.2.3",
     "react": "17.0.1",
     "react-dom": "17.0.1"
   }


### PR DESCRIPTION
I had an issue "Error: Cannot find module 'sharp'" while building the next project. I found this Stack Overflow:  https://stackoverflow.com/questions/65894000/install-sharp-without-github-fetch-for-nextjs-error-cannot-find-module-sharp

Updating next to 10.2.3 worked for me
I am using node v16.15.0