### PR TITLE
Update Modal.css

### DIFF
--- a/code/03-using-css-animations/src/components/Modal/Modal.css
+++ b/code/03-using-css-animations/src/components/Modal/Modal.css
@@ -19,6 +19,7 @@
 
 .ModalClosed {
     animation: closeModal 0.4s ease-out forwards;
+    z-index: -100;
 }
 
 @keyframes openModal {


### PR DESCRIPTION
When the model is closed we should set its z-index to some negative value since we're not displaying it none. Because with opacity the element is still there and it might overlap with other elements or a button. In my case, the element was above the "open model" button so I wasn't able to click it. This change will take care of that issue. :)